### PR TITLE
Big refactor: Track settings

### DIFF
--- a/src/components/buttons/PopoverButton.tsx
+++ b/src/components/buttons/PopoverButton.tsx
@@ -1,0 +1,50 @@
+import { Fragment, ReactNode } from 'react';
+import { Popover, Transition } from '@headlessui/react';
+import { Float } from '@headlessui-float/react';
+import { Placement } from '@floating-ui/react';
+import classNames from '../../utils/class-names.ts';
+
+export interface Props {
+  button?: ReactNode;
+  children: ReactNode;
+  className?: string;
+  panelClassName?: string;
+  buttonClassName?: string;
+  placement?: Placement;
+  autoPlacement?: boolean;
+  portal?: boolean;
+  flip?: boolean;
+  disabled?: boolean;
+}
+
+export function PopoverButton(props: Props): JSX.Element {
+  return (
+    <Popover as={Fragment}>
+      <Float
+        as={Fragment}
+        leave="transition ease-in duration-100"
+        leaveFrom="opacity-100"
+        leaveTo="opacity-0"
+        placement={props.placement ?? 'bottom'}
+        autoPlacement={props.autoPlacement}
+        portal={props.portal}
+        flip={props.flip}
+      >
+        <Popover.Button className={props.className} disabled={props.disabled}>
+          {props.button}
+        </Popover.Button>
+        <Transition as={Fragment}>
+          <Popover.Panel
+            as="div"
+            className={classNames(
+              'm-1 overflow-auto rounded-md border-2 border-gray-800 px-3 py-2 shadow-xl',
+              props.panelClassName,
+            )}
+          >
+            {props.children}
+          </Popover.Panel>
+        </Transition>
+      </Float>
+    </Popover>
+  );
+}

--- a/src/out.css
+++ b/src/out.css
@@ -773,6 +773,15 @@ select {
   margin: 0.25rem;
 }
 
+.my-5 {
+  margin-top: 1.25rem;
+  margin-bottom: 1.25rem;
+}
+
+.mb-5 {
+  margin-bottom: 1.25rem;
+}
+
 .\!block {
   display: block !important;
 }
@@ -913,8 +922,16 @@ select {
   cursor: pointer;
 }
 
+.resize {
+  resize: both;
+}
+
 .grid-flow-col {
   grid-auto-flow: column;
+}
+
+.grid-cols-\[1fr_3fr\] {
+  grid-template-columns: 1fr 3fr;
 }
 
 .grid-rows-\[0_auto_1fr\] {
@@ -927,6 +944,10 @@ select {
 
 .flex-wrap {
   flex-wrap: wrap;
+}
+
+.items-start {
+  align-items: flex-start;
 }
 
 .items-center {
@@ -949,8 +970,24 @@ select {
   gap: 0.5rem;
 }
 
+.gap-5 {
+  gap: 1.25rem;
+}
+
+.gap-3 {
+  gap: 0.75rem;
+}
+
+.overflow-auto {
+  overflow: auto;
+}
+
 .overflow-hidden {
   overflow: hidden;
+}
+
+.overflow-scroll {
+  overflow: scroll;
 }
 
 .overflow-x-hidden {
@@ -999,6 +1036,10 @@ select {
 
 .border-4 {
   border-width: 4px;
+}
+
+.border-2 {
+  border-width: 2px;
 }
 
 .border-none {
@@ -1077,6 +1118,11 @@ select {
   background-color: rgb(134 142 150 / 0.5);
 }
 
+.bg-gray-500 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(173 181 189 / var(--tw-bg-opacity));
+}
+
 .p-1 {
   padding: 0.25rem;
 }
@@ -1116,6 +1162,20 @@ select {
 .py-5 {
   padding-top: 1.25rem;
   padding-bottom: 1.25rem;
+}
+
+.px-10 {
+  padding-left: 2.5rem;
+  padding-right: 2.5rem;
+}
+
+.px-3 {
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+}
+
+.pb-10 {
+  padding-bottom: 2.5rem;
 }
 
 .text-2xl {
@@ -1189,12 +1249,42 @@ select {
   color: rgb(255 255 255 / var(--tw-text-opacity));
 }
 
+.text-transparent {
+  color: transparent;
+}
+
+.text-gray-900 {
+  --tw-text-opacity: 1;
+  color: rgb(33 37 41 / var(--tw-text-opacity));
+}
+
+.text-gray-800 {
+  --tw-text-opacity: 1;
+  color: rgb(52 58 64 / var(--tw-text-opacity));
+}
+
+.text-gray-700 {
+  --tw-text-opacity: 1;
+  color: rgb(73 80 87 / var(--tw-text-opacity));
+}
+
+.text-gray-darker {
+  --tw-text-opacity: 1;
+  color: rgb(7 19 31 / var(--tw-text-opacity));
+}
+
 .opacity-0 {
   opacity: 0;
 }
 
 .opacity-100 {
   opacity: 1;
+}
+
+.shadow-xl {
+  --tw-shadow: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
+  --tw-shadow-colored: 0 20px 25px -5px var(--tw-shadow-color), 0 8px 10px -6px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
 .outline-none {
@@ -1214,6 +1304,20 @@ select {
 
 .transition-opacity {
   transition-property: opacity;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.transition-all {
+  transition-property: all;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.transition {
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, -webkit-backdrop-filter;
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter, -webkit-backdrop-filter;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;
 }
@@ -1337,6 +1441,11 @@ body {
 .hover\:text-blue-900:hover {
   --tw-text-opacity: 1;
   color: rgb(30 58 138 / var(--tw-text-opacity));
+}
+
+.hover\:text-white:hover {
+  --tw-text-opacity: 1;
+  color: rgb(255 255 255 / var(--tw-text-opacity));
 }
 
 .hover\:shadow-md:hover {

--- a/src/sequencer/Scales.ts
+++ b/src/sequencer/Scales.ts
@@ -1,5 +1,6 @@
 // Define common musical scales in integer notation.
 import { Note } from 'tone/build/esm/core/type/NoteUnits';
+import { noteOffsets, noteValues } from '../utils/note-order.ts';
 
 const scales = {
   Chromatic: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
@@ -14,27 +15,6 @@ const scales = {
 
 /** Builds a scale starting from a root note. */
 function buildScale(root: Note, scale: readonly number[]): Note[] {
-  const noteValues = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
-  const noteOffsets: Record<string, number> = {
-    C: 0,
-    'C#': 1,
-    D: 2,
-    'D#': 3,
-    E: 4,
-    F: 5,
-    'F#': 6,
-    G: 7,
-    'G#': 8,
-    A: 9,
-    'A#': 10,
-    B: 11,
-    Db: 1,
-    Eb: 3,
-    Gb: 6,
-    Ab: 8,
-    Bb: 10,
-  };
-
   const parsedNote = /^([A-G]#?|Db|Eb|Gb|Ab|Bb)(-?\d+)$/.exec(root);
   if (!parsedNote) throw new Error('Invalid note format');
 

--- a/src/sequencer/Sequencer.tsx
+++ b/src/sequencer/Sequencer.tsx
@@ -10,7 +10,7 @@ import snare from '../assets/audio/demo-drums/demo_drums_snare.wav';
 import hihat from '../assets/audio/demo-drums/demo_drums_hi_hat.wav';
 import { getNotes } from './track/TrackInitializationSettings.ts';
 import { buildScale, scales } from './Scales.ts';
-import { sortNotes } from '../utils/note-order.ts';
+import { shift, sortNotes } from '../utils/note-order.ts';
 import { AnyTrackSettings } from './track/track.index.ts';
 import { scheduleGrid } from './Song.ts';
 
@@ -24,7 +24,7 @@ function Sequencer() {
       id: 'square8 synth',
       name: 'square8 synth',
       type: 'synth',
-      instrument: { oscillator: { type: 'square8' } },
+      instrument: { oscillator: { type: 'square8', mute: false }, volume: -10 },
       notes: scale,
     },
     'demo drums': {
@@ -35,6 +35,10 @@ function Sequencer() {
         kick: kick,
         snare: snare,
         hihat: hihat,
+      },
+      settings: {
+        volume: -10,
+        mute: false,
       },
     },
     'custom synth': {
@@ -52,7 +56,7 @@ function Sequencer() {
           type: 'custom',
         },
       },
-      notes: scale,
+      notes: shift(-12, ...scale),
     },
   });
 
@@ -92,6 +96,7 @@ function Sequencer() {
         {globalTrackState.tracks.map((track, idx) => (
           <SequencerGrid
             key={idx}
+            trackId={track.trackId}
             name={trackSettings[track.trackId].name ?? 'Track'}
             grid={track.grid}
             setGrid={(grid) => {
@@ -114,6 +119,9 @@ export const SequencerContext = React.createContext<SequencerState>({
       throw new Error('SequencerContext not initialized.');
     },
     updateInstrumentSettings: () => {
+      throw new Error('SequencerContext not initialized.');
+    },
+    getTrack: () => {
       throw new Error('SequencerContext not initialized.');
     },
   },

--- a/src/sequencer/Song.ts
+++ b/src/sequencer/Song.ts
@@ -12,6 +12,7 @@ export type PlayableInstrument<N extends string> = {
   /** Sets settings partial */
   updateSettings(settings: object): void;
   trigger(note: N, duration: Subdivision, time: number): void;
+  dispose(): void;
 };
 
 export interface GridScheduleSettings<N extends string> {

--- a/src/sequencer/Song.ts
+++ b/src/sequencer/Song.ts
@@ -9,6 +9,8 @@ export type NoteBlock<N extends string> = {
 export type NoteGrid<N extends string> = NoteBlock<N>[][];
 
 export type PlayableInstrument<N extends string> = {
+  /** Sets settings partial */
+  updateSettings(settings: object): void;
   trigger(note: N, duration: Subdivision, time: number): void;
 };
 

--- a/src/sequencer/Song.ts
+++ b/src/sequencer/Song.ts
@@ -13,6 +13,7 @@ export type PlayableInstrument<N extends string> = {
   updateSettings(settings: object): void;
   trigger(note: N, duration: Subdivision, time: number): void;
   dispose(): void;
+  node(): Tone.ToneAudioNode;
 };
 
 export interface GridScheduleSettings<N extends string> {

--- a/src/sequencer/track/AudioSourceTrack.ts
+++ b/src/sequencer/track/AudioSourceTrack.ts
@@ -1,7 +1,10 @@
 import { TrackSettings } from './TrackSettings.ts';
+import { RecursivePartial } from 'tone/Tone/core/util/Interface.ts';
+import { PlayerOptions } from 'tone';
 
 export interface AudioSourceTrackSettings<K extends string> extends TrackSettings<'audio-source'> {
   name?: string;
   /** URLs to different audio sources, associated to keys. */
   sources: Record<K, string>;
+  settings: RecursivePartial<PlayerOptions>;
 }

--- a/src/sequencer/track/AudioSourceTrack.ts
+++ b/src/sequencer/track/AudioSourceTrack.ts
@@ -1,47 +1,7 @@
-import { InitializedTrackSetting } from './TrackInitializationSettings.ts';
-import DisposeFunction from '../../utils/DisposeFunction.ts';
-import { makeGrid } from '../SequencerGrid.tsx';
-import { scheduleGrid } from '../Song.ts';
-import { Subdivision } from 'tone/build/esm/core/type/Units';
-import * as Tone from 'tone';
+import { TrackSettings } from './TrackSettings.ts';
 
-export interface AudioSourceTrackSettings<K extends string> {
-  type: 'audio-source';
+export interface AudioSourceTrackSettings<K extends string> extends TrackSettings<'audio-source'> {
   name?: string;
   /** URLs to different audio sources, associated to keys. */
   sources: Record<K, string>;
-}
-
-export /** Builds players and grid, and schedules triggers.
- * @return Function to dispose of scheduled triggers and player. */
-function initializeAudioSourceTrack(
-  settings: AudioSourceTrackSettings<string>,
-  onInit: (settings: InitializedTrackSetting<AudioSourceTrackSettings<string>>) => void,
-): DisposeFunction {
-  const { sources } = settings;
-  const grid = makeGrid(Object.keys(sources));
-
-  const players = new Tone.Players(sources).toDestination();
-
-  // Initialize the tracks
-  const id = scheduleGrid({
-    grid,
-    instruments: Object.keys(sources).map(() => ({
-      trigger(note: string, duration: Subdivision, time: number) {
-        players
-          .player(note)
-          .start(time)
-          .stop(Tone.Time(duration).toSeconds() + time);
-      },
-    })),
-  });
-
-  // Call the onInit callback with the settings
-  onInit({ ...settings, grid });
-
-  // build a dispose function
-  return () => {
-    Tone.Transport.clear(id);
-    players.dispose();
-  };
 }

--- a/src/sequencer/track/SynthTrack.ts
+++ b/src/sequencer/track/SynthTrack.ts
@@ -1,48 +1,10 @@
 import { RecursivePartial } from 'tone/Tone/core/util/Interface.ts';
 import { Note } from 'tone/build/esm/core/type/NoteUnits';
 import * as Tone from 'tone';
-import { InitializedTrackSetting } from './TrackInitializationSettings.ts';
-import { makeGrid } from '../SequencerGrid.tsx';
-import { copySynth } from '../DemoSynths.ts';
-import { scheduleGrid } from '../Song.ts';
-import DisposeFunction from '../../utils/DisposeFunction.ts';
+import { TrackSettings } from './TrackSettings.ts';
 
-export interface SynthTrackSettings {
-  type: 'synth';
+export interface SynthTrackSettings extends TrackSettings<'synth'> {
   name?: string;
   instrument: RecursivePartial<Tone.SynthOptions>;
   notes: Note[];
-}
-
-/** Builds synths and grid, and schedules triggers.
- * @return Function to dispose of scheduled triggers and synths.
- */
-export function initializeSynthTrack(
-  settings: SynthTrackSettings,
-  onInit: (settings: InitializedTrackSetting<SynthTrackSettings, Note>) => void,
-): DisposeFunction {
-  const { instrument } = settings;
-  const grid = makeGrid(settings.notes);
-
-  // Initialize synths
-  const synths = copySynth(grid.length, instrument);
-
-  // Initialize the tracks
-  const id = scheduleGrid({
-    grid,
-    instruments: synths.map((synth) => ({
-      trigger(note: string, duration: string, time: number) {
-        synth.triggerAttackRelease(note, duration, time);
-      },
-    })),
-  });
-
-  // Call the onInit callback with the settings
-  onInit({ ...settings, grid });
-
-  // build a dispose function
-  return () => {
-    Tone.Transport.clear(id);
-    synths.forEach((synth) => synth.dispose());
-  };
 }

--- a/src/sequencer/track/TrackInitializationSettings.ts
+++ b/src/sequencer/track/TrackInitializationSettings.ts
@@ -2,6 +2,7 @@ import { SynthTrackSettings } from './SynthTrack.ts';
 import { AudioSourceTrackSettings } from './AudioSourceTrack.ts';
 import { NoteGrid } from '../Song.ts';
 import { Note } from 'tone/build/esm/core/type/NoteUnits';
+import { AnyTrackSettings } from './track.index.ts';
 
 export type InitializedTrackSetting<
   Settings extends SynthTrackSettings | AudioSourceTrackSettings<string>,
@@ -12,7 +13,7 @@ export type InitializedTrackSetting<
 
 /** Returns notes of a given track.
  *  @throws {UnknownTrackTypeError} if track type is unsupported. */
-export function getNotes(settings: AnyInitializedTrackSettings): string[] {
+export function getNotes(settings: AnyTrackSettings): string[] {
   if (settings.type === 'synth') {
     return settings.notes;
   } else if (settings.type === 'audio-source') {

--- a/src/sequencer/track/TrackSettings.ts
+++ b/src/sequencer/track/TrackSettings.ts
@@ -1,0 +1,7 @@
+export type TrackId = string | number;
+
+export interface TrackSettings<T> {
+  id: TrackId;
+  type: T;
+  name?: string;
+}

--- a/src/sequencer/track/UseTrack.ts
+++ b/src/sequencer/track/UseTrack.ts
@@ -1,65 +1,157 @@
-import { initializeSynthTrack } from './SynthTrack.ts';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { AnyTrackSettings } from './track.index.ts';
-import { initializeAudioSourceTrack } from './AudioSourceTrack.ts';
-import DisposeFunction from '../../utils/DisposeFunction.ts';
-import { AnyInitializedTrackSettings, UnknownTrackTypeError } from './TrackInitializationSettings.ts';
+import { getNotes, UnknownTrackTypeError } from './TrackInitializationSettings.ts';
+import { NoteGrid, PlayableInstrument } from '../Song.ts';
+import { Note } from 'tone/build/esm/core/type/NoteUnits';
+import { TrackId } from './TrackSettings.ts';
+import { makeGrid } from '../SequencerGrid.tsx';
+import { copySynth } from '../DemoSynths.ts';
+import { Subdivision } from 'tone/build/esm/core/type/Units';
+import * as Tone from 'tone';
 
-export interface TrackState {
-  tracks: AnyInitializedTrackSettings[];
-  updateTrack(trackIndex: number, settings: AnyInitializedTrackSettings): void;
+export interface GlobalTrackState {
+  tracks: TrackState<string | Note>[];
+  updateGrid(trackId: TrackId, grid: NoteGrid<string | Note>): void;
+  updateInstrumentSettings(trackId: TrackId, settings: object): void;
 }
 
-export default function useTrack(...tracks: AnyTrackSettings[]): TrackState {
-  const serializedTracks = JSON.stringify(tracks);
+export interface TrackState<Note extends string> {
+  trackId: TrackId;
+  grid: NoteGrid<Note>;
+  instrument: PlayableInstrument<Note>;
+}
 
-  const [t, setTracks] = useState<AnyInitializedTrackSettings[]>([]);
+type TrackCache<T> = Record<TrackId, T>;
 
+export default function useTrack(...tracks: AnyTrackSettings[]): GlobalTrackState {
+  const instruments = useRef<TrackCache<PlayableInstrument<string>>>({});
+  const [gridState, setGrids] = useState<TrackCache<NoteGrid<string | Note>>>(
+    {} as TrackCache<NoteGrid<string | Note>>,
+  );
+
+  // If notes have changed update grid rows
+  // and update the instrument instances
+  const hasChanged = tracks
+    .flatMap((track) => (track.type === 'synth' ? track.notes : Object.keys(track.sources)))
+    .toString();
+
+  const state = useMemo(
+    () =>
+      Object.fromEntries(
+        tracks.map((track) => {
+          // Grids are synchronized with the tracks
+          // based on the notes (for synths) or sources (for audio sources)
+          const syncedGrid = initializeGrid(track, tracks, gridState);
+
+          // Instruments are synchronized in the same way, as synths need to be copied
+          // and audio sources need to be loaded.
+          // FIXME: Switching audio sources kills the current player. Not sure if I can do better here
+          const syncedInstruments = initializeInstruments(track, syncedGrid, instruments.current);
+
+          // Update settings of the managed instancessof Tone instruments
+          syncedInstruments.updateSettings(track.type === 'synth' ? track.instrument : track.sources);
+
+          return [track.id, { syncedGrid, syncedInstruments }];
+        }),
+      ),
+    [hasChanged],
+  );
+
+  // Sync the updated grids with the state
   useEffect(() => {
-    return initializeTracks(tracks, setTracks);
-  }, [serializedTracks]);
+    setGrids(Object.fromEntries(Object.entries(state).map(([id, { syncedGrid }]) => [id, syncedGrid])));
+  }, [JSON.stringify(state)]);
 
-  return {
-    tracks: t,
-    updateTrack(trackIndex: number, settings: AnyInitializedTrackSettings) {
-      setTracks(t.map((track, i) => (i === trackIndex ? settings : track)));
-    },
-  };
+  return useMemo(() => {
+    return {
+      tracks: tracks.map((track) => {
+        const grid = state[track.id].syncedGrid;
+        const instrument = instruments.current[track.id];
+
+        return {
+          trackId: track.id,
+          grid,
+          instrument,
+        };
+      }),
+      updateGrid(trackId: TrackId, grid: NoteGrid<string | Note>): void {
+        setGrids({
+          ...gridState,
+          [trackId]: grid,
+        });
+      },
+      updateInstrumentSettings(trackId: TrackId, settings: object): void {
+        const instrument = instruments.current[trackId];
+        instrument.updateSettings(settings);
+      },
+    };
+  }, [hasChanged]);
 }
 
-/** Initializes the tracks and calls the onInit callback with the settings.
- *  Supports synths and audio sources.
- *  @throws {UnknownTrackTypeError} if track type is unsupported.
- *  @returns Function to dispose of all tracks and their associated audio nodes.
- */
-function initializeTracks(
+function initializeGrid(
+  track: AnyTrackSettings,
   tracks: AnyTrackSettings[],
-  onInit: (settings: AnyInitializedTrackSettings[]) => void,
-): DisposeFunction {
-  const init: AnyInitializedTrackSettings[] = [];
+  cache: TrackCache<NoteGrid<string | Note>>,
+): NoteGrid<string | Note> {
+  const { id } = track;
+  if (!cache[id]) {
+    cache[id] = makeGrid(getNotes(track));
+  }
 
-  // Initialize the tracks
-  const clearAll: () => void = tracks
-    .map((settings) => {
-      if (settings.type === 'synth') {
-        return initializeSynthTrack(settings, (ts) => init.push(ts));
-      }
-      if (settings.type === 'audio-source') {
-        return initializeAudioSourceTrack(settings, (ts) => init.push(ts));
-      }
+  // resize array if necessary
+  const grid = cache[id];
+  if (grid.length !== tracks.length) {
+    const newGrid = makeGrid(getNotes(track));
 
-      throw new UnknownTrackTypeError(settings['type'] ?? `undefined`);
-    })
-    .reduce(
-      (dispose, clear) => () => {
-        dispose?.();
-        clear?.();
-      },
-      () => {},
-    );
+    // copy old values
+    for (let i = 0; i < grid.length; i++) {
+      newGrid[i] = grid[i];
+    }
 
-  // Call the onInit callback with the settings
-  onInit(init);
+    cache[id] = newGrid;
+  }
 
-  return clearAll;
+  return cache[id];
+}
+
+function initializeInstruments(
+  track: AnyTrackSettings,
+  grid: NoteGrid<string>,
+  cache: TrackCache<PlayableInstrument<string | Note>>,
+): PlayableInstrument<string | Note> {
+  const { id } = track;
+  if (!cache[id]) {
+    if (track.type === 'synth') {
+      const synths = copySynth(grid.length, track.instrument);
+      cache[id] = {
+        trigger(note: Note, duration: Subdivision, time: number): void {
+          synths.forEach((synth) => synth.triggerAttackRelease(note, duration, time));
+        },
+        updateSettings(settings: object): void {
+          synths.forEach((synth) => synth.set(settings));
+        },
+      };
+    } else if (track.type === 'audio-source') {
+      let players = new Tone.Players(track.sources).toDestination();
+      cache[id] = {
+        trigger(note: Note, duration: Subdivision, time: number): void {
+          players
+            .player(note)
+            .start(time)
+            .stop(Tone.Time(duration).toSeconds() + time);
+        },
+        updateSettings(settings: object): void {
+          const newSources = settings as Record<string, string>;
+          const hasChanged = Object.keys(newSources).some((key) => newSources[key] !== track.sources[key]);
+
+          if (hasChanged) {
+            players.dispose();
+            players = new Tone.Players(newSources).toDestination();
+          }
+        },
+      };
+    } else throw new UnknownTrackTypeError(track['type'] ?? `undefined`);
+  }
+
+  return cache[id];
 }

--- a/src/sequencer/track/UseTrack.ts
+++ b/src/sequencer/track/UseTrack.ts
@@ -30,10 +30,15 @@ export default function useTrack(...tracks: AnyTrackSettings[]): GlobalTrackStat
     {} as TrackCache<NoteGrid<string | Note>>,
   );
 
-  // If notes have changed update grid rows
-  // and update the instrument instances
+  // If notes or settings have changed, propagate the changes to the state
   const hasChanged = tracks
-    .flatMap((track) => (track.type === 'synth' ? track.notes : Object.keys(track.sources)))
+    .flatMap((track) =>
+      track.type === 'synth'
+        ? track.notes
+        : Object.entries(track.sources)
+            .flat()
+            .concat(Object.entries(track.settings).flatMap(([k, v]) => [k, String(v)])),
+    )
     .toString();
 
   const state = useMemo(

--- a/src/sequencer/track/UseTrack.ts
+++ b/src/sequencer/track/UseTrack.ts
@@ -134,7 +134,7 @@ function initializeInstruments(
         },
       }));
     } else if (track.type === 'audio-source') {
-      let players = new Tone.Players(track.sources).toDestination();
+      const players = new Tone.Players(track.sources).toDestination();
       cache[id] = Object.keys(track.sources).map((src) => ({
         trigger(note: Note, duration: Subdivision, time: number): void {
           players
@@ -143,13 +143,9 @@ function initializeInstruments(
             .stop(Tone.Time(duration).toSeconds() + time);
         },
         updateSettings(settings: object): void {
-          const newSources = settings as Record<string, string>;
-          const hasChanged = Object.keys(newSources).some((key) => newSources[key] !== track.sources[key]);
-
-          if (hasChanged) {
-            players.dispose();
-            players = new Tone.Players(newSources).toDestination();
-          }
+          Object.keys(track.sources).forEach((key) => {
+            players.player(key).set(settings);
+          });
         },
         dispose() {
           players.player(src).dispose();
@@ -197,13 +193,9 @@ function initializeInstruments(
               .stop(Tone.Time(duration).toSeconds() + time);
           },
           updateSettings(settings: object): void {
-            const newSources = settings as Record<string, string>;
-            const hasChanged = Object.keys(newSources).some((key) => newSources[key] !== track.sources[key]);
-
-            if (hasChanged) {
-              newPlayers.dispose();
-              newPlayers = new Tone.Players(newSources).toDestination();
-            }
+            Object.keys(track.sources).forEach((key) => {
+              newPlayers.player(key).set(settings);
+            });
           },
           dispose() {
             newPlayers.player(src).dispose();

--- a/src/utils/note-order.ts
+++ b/src/utils/note-order.ts
@@ -17,6 +17,27 @@ const accidentalValues: { [key: string]: number } = {
   x: 2,
 };
 
+export const noteValues = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
+export const noteOffsets: Record<string, number> = {
+  C: 0,
+  'C#': 1,
+  D: 2,
+  'D#': 3,
+  E: 4,
+  F: 5,
+  'F#': 6,
+  G: 7,
+  'G#': 8,
+  A: 9,
+  'A#': 10,
+  B: 11,
+  Db: 1,
+  Eb: 3,
+  Gb: 6,
+  Ab: 8,
+  Bb: 10,
+};
+
 /** Given a note, returns a score to sort it in order of pitch (low pitch, low score) */
 function getNoteScore(note: Note): number {
   const noteParts = note.match(/([A-G])(x|#|bb|b)?(-?\d+)/);
@@ -30,6 +51,23 @@ function getNoteScore(note: Note): number {
   const octaveNumber = parseInt(octave, 10);
 
   return (octaveNumber + 1) * 12 + baseValue + accidentalAdjustment; // "+1" to handle negative octave numbers correctly
+}
+
+/** Shifts pitch by given amount of steps. */
+export function shift(step: number, ...notes: Note[]): Note[] {
+  return notes.map((note) => {
+    const parsedNote = /^([A-G]#?|Db|Eb|Gb|Ab|Bb)(-?\d+)$/.exec(note);
+    if (!parsedNote) throw new Error('Invalid note format');
+
+    const [, baseNote, octave] = parsedNote;
+    const baseIndex = noteOffsets[baseNote];
+    const totalSteps = baseIndex + step;
+    const newIndex = ((totalSteps % 12) + 12) % 12; // Ensuring positive indices
+    const newOctave = parseInt(octave, 10) + Math.floor((baseIndex + step) / 12);
+
+    const newNote = noteValues[newIndex] + newOctave;
+    return newNote as Note;
+  });
 }
 
 function sortNotes(notes: Note[]): Note[] {


### PR DESCRIPTION
Big changes in the code:
1. Separating logic in UseTrack.ts – We hold a reference to the instruments from Tone, while keeping the grid as a local react state we track and synchronize. 
2. No more useEffect lifecycle for the whole thing. We set the triggers once, at play time, then somehow Tone keeps the correct reference to the most recent react state. Not sure how, but it works. Now we can change settings live from props and propagate them.